### PR TITLE
Hide browse button of the resource picker in widget blog list

### DIFF
--- a/Form/WidgetBlogType.php
+++ b/Form/WidgetBlogType.php
@@ -42,7 +42,8 @@ class WidgetBlogType extends AbstractType
                         'data-is-picker-multi-select-allowed' => 0,
                         'data-is-directory-selection-allowed' => 0,
                         'data-type-white-list'                => 'icap_blog',
-                        'data-display-download-button'        => 0
+                        'data-display-download-button'        => 0,
+                        'data-display-browse-button'          => 0
                     )
                 ));
     }


### PR DESCRIPTION
Need this PR https://github.com/claroline/CoreBundle/pull/986 to be merge.